### PR TITLE
Fix catalog source for K8s Operator deployment

### DIFF
--- a/deploy/kubernetes/1.3.0/operator-deploy/deploy.sh
+++ b/deploy/kubernetes/1.3.0/operator-deploy/deploy.sh
@@ -235,9 +235,9 @@ deploy_cte_csi()
         VALIDATE="--validate=false"
         # the catalog for CteK8sOperator is deployed differently on Kubernetes. Adjust the yaml file
         # TBD TBD TBD TBD
-        # The "source" will change to "community-operators" once the catalog is published for K8s
+        # The "source" will change to "operatorhubio-catalog" once the catalog is published for K8s
         # TBD TBD TBD TBD
-        sed -i s/"^  source: .*"/"  source: ctek8soperator-catalog"/g ${DEPLOY_SCRIPT_PATH}/ctek8soperator-subscription.yaml
+        sed -i s/"^  source: .*"/"  source: operatorhubio-catalog"/g ${DEPLOY_SCRIPT_PATH}/ctek8soperator-subscription.yaml
         sed -i s/"^  sourceNamespace: .*"/"  sourceNamespace: olm"/g ${DEPLOY_SCRIPT_PATH}/ctek8soperator-subscription.yaml
     fi
 


### PR DESCRIPTION
For Deployment on Kubernetes clusters, the CTE-K8s Operator subscription manifest must refer to the operatorhubio-catalog.