### PR TITLE
Add missing cte-csi-node role RBAC permissions

### DIFF
--- a/deploy/kubernetes/1.4.0/operator-deploy/cte-csi-nodeserver-rbac-role.yaml
+++ b/deploy/kubernetes/1.4.0/operator-deploy/cte-csi-nodeserver-rbac-role.yaml
@@ -1,3 +1,4 @@
+---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -13,7 +14,7 @@ rules:
 
   - apiGroups: [""]
     resources: ["configmaps"]
-    verbs: ["create", "get", "update", "delete"]
+    verbs: ["create", "get", "list", "update", "delete"]
 
   - apiGroups: [""]
     resources: ["persistentvolumes"]
@@ -21,11 +22,11 @@ rules:
 
   - apiGroups: [""]
     resources: ["nodes"]
-    verbs: ["get"]
+    verbs: ["get", "list"]
 
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
-    verbs: ["get", "patch"]
+    verbs: ["get", "list", "patch"]
 
   - apiGroups: ["storage.k8s.io"]
     resources: ["csinodes", "storageclasses"]
@@ -46,6 +47,10 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "watch", "list", "delete", "update", "create"]
+
+  - apiGroups: ["", "apps"]
+    resources: ["daemonsets", "deployments", "replicasets", "events", "replicationcontrollers", "services", "pods/log"]
+    verbs: ["get", "list"]
 
   - apiGroups: ["security.openshift.io"]
     resources: ["securitycontextconstraints"]


### PR DESCRIPTION
The cluster Role associated with cte-csi-node Service Account is missing some RBAC permissions that can cause some operations to fail.

Adding the required permissions.